### PR TITLE
Updated university name

### DIFF
--- a/psuthesis.cls
+++ b/psuthesis.cls
@@ -425,7 +425,7 @@ I grant The Pennsylvania State University the non-exclusive right to use this wo
 \vfill
 \vfill
 \begin{center}
-    A dissertation submitted to the \\ Faculty of the Graduate School of \\ the University at Buffalo, State University of New York \\ in partial fulfilment of the requirements for the \\ degree of
+    A dissertation submitted to the \\ faculty of the Graduate School of \\ the University at Buffalo, The State University of New York \\ in partial fulfilment of the requirements for the degree of
 \end{center}
 \vfill
 \begin{center}


### PR DESCRIPTION
Edited the official university name to "University at Buffalo, The State University of New York" from "University at Buffalo, State University of New York". Also removed a newline command and changed "Faculty" to "faculty". All changes are based on the guidelines document: http://grad.buffalo.edu/content/dam/grad/study/sample-title-page.pdf (which can be obtained from http://grad.buffalo.edu/succeed/graduate/electronic-submission/guidelines.html).